### PR TITLE
Fix the looping issue on the HTTP request

### DIFF
--- a/lib/cheers.js
+++ b/lib/cheers.js
@@ -70,9 +70,6 @@
                     url: config.url
                 };
 
-                console.log(curlOptions);
-                console.log('----');
-
                 curlrequest.request(curlOptions, function (err, html) {
                     var results = extractResults(html,config);
 


### PR DESCRIPTION
There is an issue where the HTTP request is multiplied by the number of properties to scrape, because the call to curlrequest is inside `for(var key in config.scrape){`.

Additionally, when there are several properties to scrape and one of them doesn't have an `extract`, the promise is correctly rejected but the script tries to scrape the url anyway as soon as it loops over a correctly formatted property, throwing an error on `mapping["extract"].toLowerCase()`. 
