### PR TITLE
Added curlOptions to config. Object curlOptions will be passed to curl as options.

### DIFF
--- a/lib/cheers.js
+++ b/lib/cheers.js
@@ -66,9 +66,13 @@
                 deferred.reject(mappingErrors);
             }else{
                 //curl based scraper
-                var curlOptions = {
-                    url: config.url
-                };
+
+                var curlOptions;
+                if(config.curlOptions !== undefined) {
+                    curlOptions = config.curlOptions;
+                }
+
+                curlOptions.url = config.url,
 
                 curlrequest.request(curlOptions, function (err, html) {
                     var results = extractResults(html,config);


### PR DESCRIPTION
I need to change the encoding in curl.

No I can do something like this, if I get the wrong encoding:
```
var config = {
    url: 'http://somesite.org',
    curlOptions: {
        encoding: null,
        process: function(body) {
            var iconv = new Iconv('ISO-8859-1', 'UTF-8');
            return iconv.convert(body).toString();
        }
    },
    ...
```
