### PR TITLE
Possibility to use culrequest options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Configuration options:
 - `config.url` : the URL to scrape
 - `config.blockSelector` : the CSS selector to apply on the page to divide it in scraping blocks. This field is optional (will use "body" by default)
 - `config.scrape` : the definition of what you want to extract in each block. Each key has two *mandatory* attributes : `selector` (a CSS selector or `.` to stay on the current node) and `extract`. The possible values for `extract` are **text**, **html**, **outerHTML**, <b>a RegExp</b> or the <b>name of an attribute</b> of the html element (e.g. "href")
+- `config.curlOptions` : additionnal options you want to pass to curl. See the documentation from https://github.com/chriso/curlrequest for more information. 
 
 
 <pre>
@@ -37,6 +38,9 @@ var cheers = require('cheers');
 //let's scrape this excellent JS news website
 var config = {
     url: "http://www.echojs.com/",
+    curlOptions: {
+        'useragent': 'Cheers'
+    },    
     blockSelector: "article",
     scrape: {
         title: {
@@ -72,7 +76,7 @@ cheers.scrape(config).then(function (results) {
 ## Roadmap
 
 - Option to use request instead of curl
-- Option to change the user agent
+~~- Option to change the user agent~~
 - Command line tool
 - Website pagination
 - Option to use a headless browser

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cheers.scrape(config).then(function (results) {
 ## Roadmap
 
 - Option to use request instead of curl
-~~- Option to change the user agent~~
+- ~~Option to change the user agent~~
 - Command line tool
 - Website pagination
 - Option to use a headless browser

--- a/example/simpleExample.js
+++ b/example/simpleExample.js
@@ -2,7 +2,10 @@ var cheers = require('../lib/cheers.js');
 
 //let's scrape this excellent JS news website
 var config = {
-    url: "http://www.echojs.com/",
+    url: "http://www.echojs.com/",    
+    curlOptions: {
+        'useragent': 'Cheers'
+    },
     blockSelector: "article",
     scrape: {
         title: {

--- a/lib/cheers.js
+++ b/lib/cheers.js
@@ -66,9 +66,8 @@
                 deferred.reject(mappingErrors);
             }else{
                 //curl based scraper
-                var curlOptions = {
-                    url: config.url
-                };
+                var curlOptions = config.curlOptions ? config.curlOptions: {};
+                curlOptions.url = config.url;
 
                 curlrequest.request(curlOptions, function (err, html) {
                     var results = extractResults(html,config);


### PR DESCRIPTION
curlOptions can now be added to the config. It can be safely omitted if not necessary. 

var config = {
    url: "http://www.echojs.com/",    
    curlOptions: {
        'useragent': 'Cheers'
    },
......

[Thu, 06 Aug 2015 19:02:56 GMT] "GET /app/index.html" "Cheers"

instead of 

[Thu, 06 Aug 2015 19:14:18 GMT] "GET /app/index.html" "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/5.0)"

I have updated the example & the readme accordingly. 
